### PR TITLE
Interpolate overlay opacity

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ type Props = {
   allowOverlayPressPropagation: bool,
   overlayColor: string,
   overlayOpacity: number,
+  animateOverlayOpacity: bool
 };
 
 type Event = {
@@ -154,15 +155,15 @@ export default class SideMenu extends React.PureComponent {
         }}
       >
         <Animated.View
-          pointerEvents="none"
+          pointerEvents={this.isOpen ? 'auto' : 'none'}
           style={[styles.overlay, {
             backgroundColor: this.getOverlayColor(),
-            opacity: this.state.left.interpolate({
+            opacity: this.props.animateOverlayOpacity ? this.state.left.interpolate({
               inputRange: [
                 this.state.hiddenMenuOffset,
                 this.state.openMenuOffset],
               outputRange: [0, this.props.overlayOpacity],
-            }),
+            }) : this.props.overlayOpacity,
           }]}
         />
       </TouchableWithoutFeedback>
@@ -332,4 +333,5 @@ SideMenu.defaultProps = {
   bounceBackOnOverdraw: true,
   autoClosing: true,
   overlayOpacity: 1,
+  animateOverlayOpacity: true,
 };

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ type Props = {
   autoClosing: bool,
   allowOverlayPressPropagation: bool,
   overlayColor: string,
+  overlayOpacity: number,
 };
 
 type Event = {
@@ -103,7 +104,7 @@ export default class SideMenu extends React.PureComponent {
       left,
     };
 
-    this.state.left.addListener(({value}) => this.props.onSliding(Math.abs((value - this.state.hiddenMenuOffset) / (this.state.openMenuOffset - this.state.hiddenMenuOffset))));
+    this.state.left.addListener(({ value }) => this.props.onSliding(Math.abs((value - this.state.hiddenMenuOffset) / (this.state.openMenuOffset - this.state.hiddenMenuOffset))));
   }
 
   UNSAFE_componentWillMount(): void {
@@ -123,12 +124,12 @@ export default class SideMenu extends React.PureComponent {
   }
 
   getOverlayColor() {
-    if(this.props.allowOverlayPressPropagation) return this.props.overlayColor || "transparent"
+    if (this.props.allowOverlayPressPropagation) return this.props.overlayColor || 'transparent';
     // stopPropagation doesn't work with transparent background
-    if(!this.props.overlayColor || this.props.overlayColor == "transparent") {
-      return '#00000001'
+    if (!this.props.overlayColor || this.props.overlayColor == 'transparent') {
+      return '#00000001';
     }
-    return this.props.overlayColor
+    return this.props.overlayColor;
   }
 
   onLayoutChange(e: Event) {
@@ -143,22 +144,29 @@ export default class SideMenu extends React.PureComponent {
    * @return {React.Component}
    */
   getContentView() {
-    let overlay: React.Element<void, void> = null;
-
-    if (this.isOpen) {
-      overlay = (
-        <TouchableWithoutFeedback
-          onPress={(e) => {
-            if(!this.props.allowOverlayPressPropagation) {
-              e.stopPropagation()
-            }
-            this.openMenu(false)
-          }}
-        >
-          <View style={[styles.overlay, { backgroundColor: this.getOverlayColor() }]} />
-        </TouchableWithoutFeedback>
+    const overlayContainer: React.Element<void, void> = (
+      <TouchableWithoutFeedback
+        onPress={(e) => {
+          if (!this.props.allowOverlayPressPropagation) {
+            e.stopPropagation();
+          }
+          this.openMenu(false);
+        }}
+      >
+        <Animated.View
+          pointerEvents="none"
+          style={[styles.overlay, {
+            backgroundColor: this.getOverlayColor(),
+            opacity: this.state.left.interpolate({
+              inputRange: [
+                this.state.hiddenMenuOffset,
+                this.state.openMenuOffset],
+              outputRange: [0, this.props.overlayOpacity],
+            }),
+          }]}
+        />
+      </TouchableWithoutFeedback>
       );
-    }
 
     const { width, height } = this.state;
     const ref = sideMenu => (this.sideMenu = sideMenu);
@@ -171,7 +179,7 @@ export default class SideMenu extends React.PureComponent {
     return (
       <Animated.View style={style} ref={ref} {...this.responder.panHandlers}>
         {this.props.children}
-        {overlay}
+        {overlayContainer}
       </Animated.View>
     );
   }
@@ -323,4 +331,5 @@ SideMenu.defaultProps = {
   isOpen: false,
   bounceBackOnOverdraw: true,
   autoClosing: true,
+  overlayOpacity: 1,
 };


### PR DESCRIPTION
This PR allows the content overlay to fade in and out by interpolating the `left` Animated.Value to the opacity style prop on the overlay. It adds two new props to the component:

- `overlayOpacity: number` with a default of `1`
- `animateOverlayOpacity: bool` with a default of `true`

and finally, it changes the rendering to _always_ render the overlay, and adds a toggle on `pointerEvents` to determine if the overlay is interactive or if touches should simply pass through the overlay to main content.

Here's what it looks like before the PR:
https://user-images.githubusercontent.com/80355384/125297478-e1991f80-e2ec-11eb-8962-46f4b7aa7971.mov
with the code:
```jsx
<SideMenu
  menu={
    <View style={{ flex: 1, backgroundColor: "white", justifyContent: "center", alignItems: "center" }}>
      <Text>This is the side menu!</Text>
    </View>
  }
  overlayColor="rgba(0, 0, 0, 0.7)"
>
  <View style={{ flex: 1, backgroundColor: "yellow", justifyContent: "center", alignItems: "center" }}>
    <Text>This is the main content!</Text>
  </View>
</SideMenu>
```


and here's what it looks like after the PR:
https://user-images.githubusercontent.com/80355384/125297549-ef4ea500-e2ec-11eb-8bdd-5b7c1f76f759.mov
with the code:
```jsx
<SideMenu
  menu={
    <View style={{ flex: 1, backgroundColor: "white", justifyContent: "center", alignItems: "center" }}>
      <Text>This is the side menu!</Text>
    </View>
  }
  overlayColor="rgb(0, 0, 0)"
  overlayOpacity={0.7}
>
  <View style={{ flex: 1, backgroundColor: "yellow", justifyContent: "center", alignItems: "center" }}>
    <Text>This is the main content!</Text>
  </View>
</SideMenu>
```

If this PR and approach is welcome, I'll update the docs in the Readme as well.

Thanks for your time and consideration!